### PR TITLE
Polish and edge case fixes on `attack` command

### DIFF
--- a/commands/combat_commands.py
+++ b/commands/combat_commands.py
@@ -24,8 +24,15 @@ class CmdAttack(default_cmds.MuxCommand):
     """
         Attack! Kill! Destroy!!!
 
+        Use the attack command to...attack an opponent during combat. Obvi.
+
+        'target' must be the name of another character to receive the attack.
+
+        'action' must be the name of the art your character will use to perform the attack.
+        This art must be among those possessed by your character.
+
         Usage:
-          +attack
+          +attack target=action
 
     """
 
@@ -40,7 +47,15 @@ class CmdAttack(default_cmds.MuxCommand):
         location = caller.location
         args = self.args
         arts = caller.db.arts
+
+        if len(args) == 0:
+            return caller.msg("You need to specify a target and art, dumb-dumb. See `help attack` for syntax.")
+
         split_args = args.split('=')
+
+        if len(split_args) != 2:
+            return caller.msg("Unrecognized command syntax. See `help attack`.")
+
         target = split_args[0].lower() # make everything case-insensitive
         action = split_args[1].lower()
 

--- a/commands/combat_commands.py
+++ b/commands/combat_commands.py
@@ -49,7 +49,7 @@ class CmdAttack(default_cmds.MuxCommand):
         arts = caller.db.arts
 
         if len(args) == 0:
-            return caller.msg("You need to specify a target and art, dumb-dumb. See `help attack` for syntax.")
+            return caller.msg("You need to specify a target and action, schmoo. See `help attack` for syntax.")
 
         split_args = args.split('=')
 


### PR DESCRIPTION
* Added verbose description to `attack` command help text, including actual syntax and description of params.
* Gracefully handled no input case.
* Gracefully handled the invalid input case.