### PR TITLE
Fixing minions app "no module named 'minions'" bug

### DIFF
--- a/world/minions/apps.py
+++ b/world/minions/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class MinionsConfig(AppConfig):
-    name = 'minions'
+    name = 'world.minions'


### PR DESCRIPTION
TL;DR: minions app is referenced in `settings.py` as `world.minions` but named `minions` in the AppConfig. Changed AppConfig to `world.minions` and it's all 👌 