### PR TITLE
Fixing migration failure in clean / new dev environment

### DIFF
--- a/world/arts/migrations/0001_initial.py
+++ b/world/arts/migrations/0001_initial.py
@@ -7,7 +7,7 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = []
+    dependencies = [("objects", "0001_initial")]
 
     operations = [
         migrations.CreateModel(

--- a/world/boards/migrations/0001_initial.py
+++ b/world/boards/migrations/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = []
+    dependencies = [("objects", "0001_initial")]
 
     operations = [
         migrations.CreateModel(

--- a/world/scenes/migrations/0001_initial.py
+++ b/world/scenes/migrations/0001_initial.py
@@ -8,6 +8,8 @@ class Migration(migrations.Migration):
 
     initial = True
 
+    dependencies = [("objects", "0001_initial")]
+
     operations = [
         migrations.CreateModel(
             name='Scene',


### PR DESCRIPTION
TL;DR: the very first `evennia migrate` in a clean client/dev-environment will fail because there is no dependency between our custom models (which reference `objects.ObjectDB`) and the migration which creates `ObjectDB` in the first place.

This PR fixes the issue by adding an explicit dependency.