### PR TITLE
Added "Revive" Effect

### DIFF
--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -111,6 +111,9 @@ class CmdSetArt(default_cmds.MuxCommand):
                             ex_move = True
                 if not effect_ok:
                     return caller.msg("Error: at least one of your Effects is not a valid Effect.")
+            # Corner casing: make sure that any art with the Revive effect also has the Heal effect.
+            if "Revive" in title_split_effects and "Heal" not in title_split_effects:
+                return caller.msg("Error: any Art with the Revive Effect must also have the Heal Effect.")
             # Having confirmed the Art is well-formed, add it to the character's list of Arts.
             # Check if it is regular Art (120 points between Damage/Acc) or EX (140 points).
             if ex_move:

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -223,6 +223,8 @@ class CmdAttack(default_cmds.MuxCommand):
         # First, check that the character attacking is not KOed
         if caller.db.KOed:
             return caller.msg("Your character is KOed and cannot act.")
+        if caller.db.stunned:
+            return caller.msg("Your character is stunned and must 'pass' this turn.")
 
         # Then check that the target is a character in the room using utility
         characters_in_room = location_character_search(location)
@@ -1023,11 +1025,9 @@ class CmdPass(default_cmds.MuxCommand):
         combat_string = "|y<COMBAT>|n {0} takes no action.".format(caller.name)
         caller.location.msg_contents(combat_string)
         combat_log_entry(caller, combat_string)
+        if caller.db.stunned:
+            caller.db.stunned = False
+            caller.msg("Your character is no longer stunned.")
         # If this was the attacker's final action, they are now KOed.
         if caller.db.final_action:
-            caller.db.final_action = False
-            caller.db.KOed = True
-            caller.msg("You have taken your final action and can no longer fight.")
-            combat_string = "|y<COMBAT>|n {0} can no longer fight.".format(caller.name)
-            caller.location.msg_contents(combat_string)
-            combat_log_entry(caller, combat_string)
+            final_action_taken(caller)

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -32,8 +32,10 @@ ex_move = Effect("EX", 5, "EX")
 rush = Effect("Rush", -5, "RSH")
 # 1) Increase accuracy if not used as interrupt. 2) Decrease all reaction chances until next action.
 # This is a hybrid current/next turn effect.
-heal = Effect("Heal", 0, "HEAL")
+heal = Effect("Heal", -10, "HEAL")
 # This Art heals instead of doing damage and is subject to heal depreciation.
+revive = Effect("Revive", -15, "REV")
+# This healing Art, when used on a KOed ally, eliminates their 1-turn inaction penalty on being healed.
 
 # Next Turn Effects
 weave = Effect("Weave", -5, "WV")
@@ -45,4 +47,4 @@ bait = Effect("Bait", -5, "BT")
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal]
+EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive]


### PR DESCRIPTION
"Revive" allows a character to act again immediately when healed up from 0 LF. Requires the Heal effect when using setart. Set minimum LF to 0, so no one has to be healed up from negatives, and created a new "stunned" state where you have to pass next turn if you are healed but not revived. It is not possible to heal or revive yourself if it is your final action.

KNOWN BUG: Neither Heal or Revive abbreviations are showing up on sheet/arts and I'm not sure why! The effects are definitely on the Arts. This was the case before I implemented Revive and I just didn't notice.