### PR TITLE
Added the Regen effect, the first proper buff.

### DIFF
--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -1,6 +1,6 @@
 from evennia import default_cmds
 from world.arts.models import Arts
-from world.combat.effects import EFFECTS, SUPPORT, DEBUFFS_HEXES, DEBUFFS_STANDARD, DEBUFFS_TRANSFORMATION
+from world.combat.effects import EFFECTS, SUPPORT, DEBUFFS
 from world.combat.attacks import Attack
 
 
@@ -115,6 +115,8 @@ class CmdSetArt(default_cmds.MuxCommand):
             for effect in title_split_effects:
                 if effect in SUPPORT and "Heal" not in title_split_effects:
                     return caller.msg(f"Error: {effect} is a Support effect. All Support Arts must have the Heal Effect.")
+                if effect in DEBUFFS and "Heal" in title_split_effects:
+                    return caller.msg(f"Error: {effect} is a Debuff effect and is not compatible with the Heal Effect.")
             # Having confirmed the Art is well-formed, add it to the character's list of Arts.
             # Check if it is regular Art (120 points between Damage/Acc) or EX (140 points).
             if ex_move:

--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -1,6 +1,6 @@
 from evennia import default_cmds
 from world.arts.models import Arts
-from world.combat.effects import EFFECTS
+from world.combat.effects import EFFECTS, SUPPORT, DEBUFFS_HEXES, DEBUFFS_STANDARD, DEBUFFS_TRANSFORMATION
 from world.combat.attacks import Attack
 
 
@@ -114,6 +114,10 @@ class CmdSetArt(default_cmds.MuxCommand):
             # Corner casing: make sure that any art with the Revive effect also has the Heal effect.
             if "Revive" in title_split_effects and "Heal" not in title_split_effects:
                 return caller.msg("Error: any Art with the Revive Effect must also have the Heal Effect.")
+            # Confirm that any Support effect is coupled with the Heal effect
+            for effect in title_split_effects:
+                if effect in SUPPORT and "Heal" not in title_split_effects:
+                    return caller.msg(f"Error: {effect} is a Support effect. All Support Arts must have the Heal Effect.")
             # Having confirmed the Art is well-formed, add it to the character's list of Arts.
             # Check if it is regular Art (120 points between Damage/Acc) or EX (140 points).
             if ex_move:

--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -111,9 +111,6 @@ class CmdSetArt(default_cmds.MuxCommand):
                             ex_move = True
                 if not effect_ok:
                     return caller.msg("Error: at least one of your Effects is not a valid Effect.")
-            # Corner casing: make sure that any art with the Revive effect also has the Heal effect.
-            if "Revive" in title_split_effects and "Heal" not in title_split_effects:
-                return caller.msg("Error: any Art with the Revive Effect must also have the Heal Effect.")
             # Confirm that any Support effect is coupled with the Heal effect
             for effect in title_split_effects:
                 if effect in SUPPORT and "Heal" not in title_split_effects:

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -284,6 +284,10 @@ class CmdAttack(default_cmds.MuxCommand):
         # Copy.copy is used to ensure we do not modify the attack in the character's list, just this instance of it.
         action_clean = copy.copy(action_clean)
 
+        # Check if the attacker is currently Berserk.
+        if caller.db.debuffs["Berserk"][0] > 0:
+            if berserk_check(caller, action_clean):
+                return caller.msg("Due to your Berserk state, you may only use attacks of 50 DMG or higher.")
         # If the character has insufficient AP or EX to use that move, cancel the attack.
         # Otherwise, set their EX from 100 to 0.
         total_ap_change = action_clean.ap
@@ -700,6 +704,10 @@ class CmdInterrupt(default_cmds.MuxCommand):
             interrupt_clean = NORMALS.get(name__iexact=outgoing_interrupt_arg)  # found action with correct capitalization
         else:
             interrupt_clean = arts.get(name__iexact=outgoing_interrupt_arg)
+        # Check if the interrupter is currently Berserk.
+        if caller.db.debuffs["Berserk"][0] > 0:
+            if berserk_check(caller, interrupt_clean):
+                return caller.msg("Due to your Berserk state, you may only use attacks of 50 DMG or higher.")
         # If the character has insufficient AP or EX to use that move, cancel the interrupt.
         # Otherwise, if EX move, set their EX from 100 to 0.
         total_ap_change = interrupt_clean.ap

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -396,7 +396,7 @@ class CmdDodge(default_cmds.MuxCommand):
         attacker_stat = find_attacker_stat(attacker, attack.stat)
         if modified_acc > random100:
             # Since the attack has hit, check for critical hit.
-            final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller.db.parry, caller.db.barrier)
+            final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
             is_critical_hit, final_damage = critical_hits(final_damage)
             # If the attack is not a critical hit, check for glancing blow (so there are no glancing crits).
             is_glancing_blow = glancing_blow_calc(random100, modified_acc, action.has_sweep)
@@ -488,7 +488,7 @@ class CmdBlock(default_cmds.MuxCommand):
         # Find the attacker's relevant attack stat for damage_calc.
         attacker_stat = find_attacker_stat(attacker, attack.stat)
         modified_acc = block_chance_calc(caller, action)
-        modified_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller.db.parry, caller.db.barrier)
+        modified_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
 
         # do the aiming/feinting modification here since we don't want to show the modified value in the queue
         if aim_or_feint == AimOrFeint.AIM:
@@ -608,7 +608,7 @@ class CmdEndure(default_cmds.MuxCommand):
 
         msg = ""
         attacker_stat = find_attacker_stat(attacker, attack.stat)
-        final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller.db.parry, caller.db.barrier)
+        final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
         if modified_acc > random100:
             # Since the attack has hit, check for critical hit.
             is_critical_hit, final_damage = critical_hits(final_damage)
@@ -738,9 +738,11 @@ class CmdInterrupt(default_cmds.MuxCommand):
             modified_acc += 15
 
         msg = ""
-        if modified_acc > random100:
+        if modified_acc < random100:
             # attack_with_effects = check_for_effects(attack)
-            final_damage = damage_calc(incoming_damage, incoming_attack_stat, incoming_attack.stat, caller.db.parry, caller.db.barrier)
+            final_damage = damage_calc(incoming_damage, incoming_attack_stat, incoming_attack.stat, caller)
+            # Check for Protect/Reflect moderate damage mitigation.
+            final_damage = protect_and_reflect_check(final_damage, caller, incoming_attack, False)
             # Since the incoming attack has hit, check for critical hit.
             is_critical_hit, final_damage = critical_hits(final_damage)
             if is_critical_hit:
@@ -775,13 +777,15 @@ class CmdInterrupt(default_cmds.MuxCommand):
         else:
             # Modify damage of outgoing interrupt based on relevant attack stat.
             modified_int_damage = modify_damage(outgoing_interrupt, caller)
-            final_outgoing_damage = damage_calc(modified_int_damage, outgoing_interrupt_stat, outgoing_interrupt.stat, attacker.db.parry, attacker.db.barrier)
+            final_outgoing_damage = damage_calc(modified_int_damage, outgoing_interrupt_stat, outgoing_interrupt.stat, attacker)
             # Check if the interrupt is a critical hit!
             is_critical_hit, final_outgoing_damage = critical_hits(final_outgoing_damage)
             # Determine how much damage the incoming attack would do if unmitigated.
-            unmitigated_incoming_damage = damage_calc(incoming_damage, incoming_attack_stat, incoming_attack.stat, caller.db.parry, caller.db.barrier)
+            unmitigated_incoming_damage = damage_calc(incoming_damage, incoming_attack_stat, incoming_attack.stat, caller)
             # Determine how the Damage of the outgoing interrupt mitigates incoming Damage.
             mitigated_damage = interrupt_mitigation_calc(unmitigated_incoming_damage, final_outgoing_damage)
+            # Check for Protect/Reflect moderate damage mitigation.
+            mitigated_damage = protect_and_reflect_check(mitigated_damage, caller, incoming_attack, True)
             if is_critical_hit:
                 caller.msg("You critically interrupt {attack} with {interrupt}!".format(attack=incoming_attack.name, interrupt=outgoing_interrupt.name))
                 caller.msg("You took {dmg} damage.".format(dmg=round(mitigated_damage)))

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -430,6 +430,10 @@ class CmdDodge(default_cmds.MuxCommand):
                 drain_check(attack, attacker, caller, final_damage)
             if "Dispel" in attack.effects:
                 dispel_check(caller)
+            if "Long-Range" in attack.effects and attacker.key not in caller.db.ranged_knockback[1]:
+                caller.db.ranged_knockback[0] = True
+                caller.db.ranged_knockback[1].append(attacker.key)
+                caller.msg("You have been knocked back from {attacker} by a ranged attack.".format(attacker=attacker.key))
             record_combat(caller, action, "dodge", False, final_damage)
         else:
             caller.msg("You have successfully dodged {attack}.".format(attack=attack.name))
@@ -545,6 +549,10 @@ class CmdBlock(default_cmds.MuxCommand):
                 drain_check(attack, attacker, caller, final_damage)
             record_combat(caller, action, "block", True, final_damage)
 
+        if "Long-Range" in attack.effects and attacker.key not in caller.db.ranged_knockback[1]:
+            caller.db.ranged_knockback[0] = True
+            caller.db.ranged_knockback[1].append(attacker.key)
+            caller.msg("You have been knocked back from {attacker} by a ranged attack.".format(attacker=attacker.key))
         combat_string = msg.format(target=caller.key, attacker=attacker.key, modifier=modifier, attack=attack.name)
         caller.location.msg_contents(combat_string)
         combat_log_entry(caller, combat_string)
@@ -636,6 +644,10 @@ class CmdEndure(default_cmds.MuxCommand):
             drain_check(attack, attacker, caller, final_damage)
         if "Dispel" in attack.effects:
             dispel_check(caller)
+        if "Long-Range" in attack.effects and attacker.key not in caller.db.ranged_knockback[1]:
+            caller.db.ranged_knockback[0] = True
+            caller.db.ranged_knockback[1].append(attacker.key)
+            caller.msg("You have been knocked back from {attacker} by a ranged attack.".format(attacker=attacker.key))
 
         combat_string = msg.format(target=caller.key, attacker=attacker.key, modifier=modifier, attack=attack.name)
         caller.location.msg_contents(combat_string)
@@ -754,6 +766,11 @@ class CmdInterrupt(default_cmds.MuxCommand):
                 drain_check(incoming_action, attacker, caller, final_damage)
             if "Dispel" in incoming_attack.effects:
                 dispel_check(caller)
+            if "Long-Range" in incoming_attack.effects and attacker.key not in caller.db.ranged_knockback[1]:
+                caller.db.ranged_knockback[0] = True
+                caller.db.ranged_knockback[1].append(attacker.key)
+                caller.msg(
+                    "You have been knocked back from {attacker} by a ranged attack.".format(attacker=attacker.key))
             record_combat(caller, incoming_action, "interrupt", False, final_damage)
         else:
             # Modify damage of outgoing interrupt based on relevant attack stat.
@@ -794,6 +811,11 @@ class CmdInterrupt(default_cmds.MuxCommand):
                 drain_check(outgoing_interrupt, caller, attacker, final_outgoing_damage)
             if "Dispel" in outgoing_interrupt.effects:
                 dispel_check(attacker)
+            if "Long-Range" in outgoing_interrupt.effects and caller.key not in attacker.db.ranged_knockback[1]:
+                attacker.db.ranged_knockback[0] = True
+                attacker.db.ranged_knockback[1].append(caller.key)
+                attacker.msg(
+                    "You have been knocked back from {caller} by a ranged attack.".format(caller=caller.key))
             record_combat(caller, incoming_action, "interrupt", True, mitigated_damage)
 
         combat_string = msg.format(target=caller.key, attacker=attacker.key, modifier=modifier,

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -156,7 +156,6 @@ class CmdSheet(default_cmds.MuxCommand):
         right_spacing = ceil(client_width / 2.0) - 3  # -2 for the borders
         sheetMsg += "|" + "=" * left_spacing + "ARTS" + "=" * right_spacing + "|"
 
-        caller.msg(client_width)
         arts_table = setup_table(client_width, is_sheet=True)
         populate_table(arts_table, arts)
         arts_string = arts_table.__str__()

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -397,7 +397,7 @@ class CmdDodge(default_cmds.MuxCommand):
         if modified_acc > random100:
             # Since the attack has hit, check for critical hit.
             final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
-            is_critical_hit, final_damage = critical_hits(final_damage)
+            is_critical_hit, final_damage = critical_hits(final_damage, attacker)
             # If the attack is not a critical hit, check for glancing blow (so there are no glancing crits).
             is_glancing_blow = glancing_blow_calc(random100, modified_acc, action.has_sweep)
             if is_critical_hit:
@@ -500,7 +500,7 @@ class CmdBlock(default_cmds.MuxCommand):
 
         if modified_acc > random100:
             # Since the attack has hit, check for critical hit.
-            is_critical_hit, final_damage = critical_hits(modified_damage)
+            is_critical_hit, final_damage = critical_hits(modified_damage, attacker)
             if is_critical_hit:
                 caller.msg("You have been critically hit by {attack}!".format(attack=attack.name))
                 caller.msg("You took {dmg} damage.".format(dmg=round(modified_damage)))
@@ -611,7 +611,7 @@ class CmdEndure(default_cmds.MuxCommand):
         final_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
         if modified_acc > random100:
             # Since the attack has hit, check for critical hit.
-            is_critical_hit, final_damage = critical_hits(final_damage)
+            is_critical_hit, final_damage = critical_hits(final_damage, attacker)
             if is_critical_hit:
                 caller.msg("You have been critically hit by {attack}!".format(attack=attack.name))
                 caller.msg("You took {dmg} damage.".format(dmg=round(final_damage)))
@@ -744,7 +744,7 @@ class CmdInterrupt(default_cmds.MuxCommand):
             # Check for Protect/Reflect moderate damage mitigation.
             final_damage = protect_and_reflect_check(final_damage, caller, incoming_attack, False)
             # Since the incoming attack has hit, check for critical hit.
-            is_critical_hit, final_damage = critical_hits(final_damage)
+            is_critical_hit, final_damage = critical_hits(final_damage, attacker)
             if is_critical_hit:
                 caller.msg("You have critically failed to interrupt {attack}!".format(attack=incoming_attack.name))
                 caller.msg("You took {dmg} damage.".format(dmg=round(final_damage)))
@@ -779,7 +779,7 @@ class CmdInterrupt(default_cmds.MuxCommand):
             modified_int_damage = modify_damage(outgoing_interrupt, caller)
             final_outgoing_damage = damage_calc(modified_int_damage, outgoing_interrupt_stat, outgoing_interrupt.stat, attacker)
             # Check if the interrupt is a critical hit!
-            is_critical_hit, final_outgoing_damage = critical_hits(final_outgoing_damage)
+            is_critical_hit, final_outgoing_damage = critical_hits(final_outgoing_damage, caller)
             # Determine how much damage the incoming attack would do if unmitigated.
             unmitigated_incoming_damage = damage_calc(incoming_damage, incoming_attack_stat, incoming_attack.stat, caller)
             # Determine how the Damage of the outgoing interrupt mitigates incoming Damage.

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -324,7 +324,7 @@ class CmdAttack(default_cmds.MuxCommand):
             combat_log_entry(caller, combat_string)
 
         # "Tick" to have a round pass.
-        combat_tick(caller)
+        combat_tick(caller, action_clean)
         # If this was the attacker's final action, they are now KOed.
         if caller.db.final_action:
             final_action_taken(caller)
@@ -828,7 +828,7 @@ class CmdInterrupt(default_cmds.MuxCommand):
             combat_log_entry(caller, combat_string)
         # If the defender survives the interrupt, do a combat tick to clear status, as with +attack and +pass.
         else:
-            combat_tick(caller)
+            combat_tick(caller, outgoing_interrupt)
             # Might have just taken poison damage and been reduced below 0 LF then! Check, but can't be KOed from that.
             final_action_check(caller)
         del caller.db.queue[id_list.index(int(incoming_attack_arg))]
@@ -1108,7 +1108,7 @@ class CmdPass(default_cmds.MuxCommand):
         # First, check that the character acting is not KOed
         if caller.db.KOed:
             return caller.msg("Your character is KOed and cannot act!")
-        combat_tick(caller)
+        combat_tick(caller, None)
         combat_string = "|y<COMBAT>|n {0} takes no action.".format(caller.name)
         caller.location.msg_contents(combat_string)
         combat_log_entry(caller, combat_string)

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -285,7 +285,7 @@ class CmdAttack(default_cmds.MuxCommand):
         action_clean = copy.copy(action_clean)
 
         # Check if the attacker is currently Berserk.
-        if caller.db.debuffs["Berserk"][0] > 0:
+        if caller.db.debuffs_standard["Berserk"] > 0:
             if berserk_check(caller, action_clean):
                 return caller.msg("Due to your Berserk state, you may only use attacks of 50 DMG or higher.")
         # If the character has insufficient AP or EX to use that move, cancel the attack.
@@ -705,7 +705,7 @@ class CmdInterrupt(default_cmds.MuxCommand):
         else:
             interrupt_clean = arts.get(name__iexact=outgoing_interrupt_arg)
         # Check if the interrupter is currently Berserk.
-        if caller.db.debuffs["Berserk"][0] > 0:
+        if caller.db.debuffs_standard["Berserk"] > 0:
             if berserk_check(caller, interrupt_clean):
                 return caller.msg("Due to your Berserk state, you may only use attacks of 50 DMG or higher.")
         # If the character has insufficient AP or EX to use that move, cancel the interrupt.
@@ -1123,6 +1123,8 @@ class CmdPass(default_cmds.MuxCommand):
         if caller.db.stunned:
             caller.db.stunned = False
             caller.msg("Your character is no longer stunned.")
+        # Clear all hexes, if applicable.
+        clear_hexes(caller)
         # If this was the attacker's final action, they are now KOed.
         if caller.db.final_action:
             final_action_taken(caller)

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -229,9 +229,15 @@ class CmdAttack(default_cmds.MuxCommand):
 
         aim_or_feint = AimOrFeint.NEUTRAL
         if caller.db.is_aiming:
-            aim_or_feint = AimOrFeint.AIM
+            if caller.db.status_effects["Haste"] > 0:
+                aim_or_feint = AimOrFeint.HASTED_AIM
+            else:
+                aim_or_feint = AimOrFeint.AIM
         if caller.db.is_feinting:
-            aim_or_feint = AimOrFeint.FEINT
+            if caller.db.status_effects["Blink"] > 0:
+                aim_or_feint = AimOrFeint.BLINKED_FEINT
+            else:
+                aim_or_feint = AimOrFeint.FEINT
 
         # First, check that the character attacking is not KOed
         if caller.db.KOed:
@@ -386,10 +392,7 @@ class CmdDodge(default_cmds.MuxCommand):
         modified_acc = dodge_calc(caller, action)
 
         # do the aiming/feinting modification here since we don't want to show the modified value in the queue
-        if aim_or_feint == AimOrFeint.AIM:
-            modified_acc += 15
-        elif aim_or_feint == AimOrFeint.FEINT:
-            modified_acc -= 15
+        modified_acc = modify_aim_and_feint(modified_acc, "dodge", aim_or_feint)
 
         msg = ""
         is_glancing_blow = False
@@ -491,10 +494,7 @@ class CmdBlock(default_cmds.MuxCommand):
         modified_damage = damage_calc(attack_damage, attacker_stat, attack.stat, caller)
 
         # do the aiming/feinting modification here since we don't want to show the modified value in the queue
-        if aim_or_feint == AimOrFeint.AIM:
-            modified_acc += 15
-        elif aim_or_feint == AimOrFeint.FEINT:
-            modified_acc -= 15
+        modified_acc = modify_aim_and_feint(modified_acc, "block", aim_or_feint)
 
         msg = ""
 
@@ -601,10 +601,7 @@ class CmdEndure(default_cmds.MuxCommand):
         modified_acc = endure_chance_calc(caller, action)
 
         # do the aiming/feinting modification here since we don't want to show the modified value in the queue
-        if aim_or_feint == AimOrFeint.AIM:
-            modified_acc -= 15
-        elif aim_or_feint == AimOrFeint.FEINT:
-            modified_acc += 15
+        modified_acc = modify_aim_and_feint(modified_acc, "endure", aim_or_feint)
 
         msg = ""
         attacker_stat = find_attacker_stat(attacker, attack.stat)
@@ -732,10 +729,7 @@ class CmdInterrupt(default_cmds.MuxCommand):
         modified_acc = interrupt_chance_calc(caller, incoming_action, outgoing_interrupt)
 
         # do the aiming/feinting modification here since we don't want to show the modified value in the queue
-        if aim_or_feint == AimOrFeint.AIM:
-            modified_acc -= 15
-        elif aim_or_feint == AimOrFeint.FEINT:
-            modified_acc += 15
+        modified_acc = modify_aim_and_feint(modified_acc, "interrupt", aim_or_feint)
 
         msg = ""
         if modified_acc < random100:

--- a/world/combat/attacks.py
+++ b/world/combat/attacks.py
@@ -1,5 +1,6 @@
 from world.combat.effects import AimOrFeint
 from world.utilities.utilities import find_attacker_from_key
+from enum import Enum
 
 
 class Attack:
@@ -89,3 +90,17 @@ class AttackToQueue(AttackDuringAction):
                     self.has_bait = True
                 if effect == "Long-Range":
                     self.has_ranged = True
+
+
+# Enumerate possible attack results to pass into the damage message string function
+class ActionResult(Enum):
+    REACT_CRIT_FAIL = 1
+    REACT_FAIL = 2
+    GLANCING_BLOW = 3
+    DODGE_SUCCESS = 4
+    BLOCK_SUCCESS = 5
+    ENDURE_SUCCESS = 6
+    INTERRUPT_CRIT_FAIL = 7
+    INTERRUPT_FAIL = 8
+    INTERRUPT_SUCCESS = 9
+    INTERRUPT_CRIT_SUCCESS = 10

--- a/world/combat/attacks.py
+++ b/world/combat/attacks.py
@@ -24,13 +24,14 @@ class Attack:
 class AttackInstance:
     # This is a class that contains an instance of an Attack (see above) as well as the attacker, an ID in the target's
     # queue, and an enum representing if the attacker was Aiming, Feinting, or neither.
-    def __init__(self, new_id, attack, attacker_key, aim_or_feint):
+    def __init__(self, new_id, attack, attacker_key, aim_or_feint, switches):
         self.id = new_id
         # self.target = target
         self.attack = attack
         self.attacker_key = attacker_key
         self.aim_or_feint = aim_or_feint
         self.modifier = ""
+        self.switches = []
         if aim_or_feint == AimOrFeint.AIM:
             self.modifier = "Aimed "
         if aim_or_feint == AimOrFeint.FEINT:

--- a/world/combat/attacks.py
+++ b/world/combat/attacks.py
@@ -45,8 +45,10 @@ class AttackInstance:
         self.has_weave = False
         self.has_brace = False
         self.has_bait = False
+        self.has_ranged = False
         if attack.effects:
-            for effect in attack.effects:
+            split_effects = attack.effects.split()
+            for effect in split_effects:
                 if effect == "Crush":
                     self.has_crush = True
                 if effect == "Sweep":
@@ -61,3 +63,5 @@ class AttackInstance:
                     self.has_brace = True
                 if effect == "Bait":
                     self.has_bait = True
+                if effect == "Long-Range":
+                    self.has_ranged = True

--- a/world/combat/combat_functions.py
+++ b/world/combat/combat_functions.py
@@ -115,6 +115,8 @@ def modify_speed(speed, defender):
         speed += 5
     if defender.db.debuffs["Petrify"][0] > 0:
         speed -= 10
+    if defender.db.debuffs["Slime"][0] > 0:
+        speed -= 10
     effective_speed = speed * speed_multiplier
     return effective_speed
 
@@ -139,6 +141,9 @@ def dodge_calc(defender, attack_instance):
     # Checking to see if the defender is Petrified and improving accuracy if so.
     if defender.db.debuffs["Petrify"][0] > 0:
         accuracy += 12
+    # Checking to see if the defender is Slimy and reducing accuracy if so.
+    if defender.db.debuffs["Slime"][0] > 0:
+        accuracy -= 12
     # cap accuracy at 99%
     if accuracy > 99:
         accuracy = 99
@@ -172,6 +177,9 @@ def block_chance_calc(defender, attack_instance):
     # Checking to see if the defender is Petrified and reducing accuracy if so.
     if defender.db.debuffs["Petrify"][0] > 0:
         accuracy -= 12
+    # Checking to see if the defender is Slimy and improving accuracy if so.
+    if defender.db.debuffs["Slime"][0] > 0:
+        accuracy += 12
     # Incorporating block penalty.
     accuracy += defender.db.block_penalty
     if accuracy > 99:
@@ -204,6 +212,9 @@ def endure_chance_calc(defender, attack_instance):
         accuracy += 5
     # Checking to see if the defender is Petrified and reducing accuracy if so.
     if defender.db.debuffs["Petrify"][0] > 0:
+        accuracy -= 12
+    # Checking to see if the defender is Slimy and reducing accuracy if so.
+    if defender.db.debuffs["Slime"][0] > 0:
         accuracy -= 12
     if accuracy > 99:
         accuracy = 99
@@ -708,6 +719,8 @@ def combat_tick(character, action):
                     character.msg("You are no longer berserk.")
                 elif status_effect == "Petrify":
                     character.msg("You are no longer petrified.")
+                elif status_effect == "Slime":
+                    character.msg("You are no longer slimy.")
 
 
 def normalize_status(character):
@@ -723,7 +736,7 @@ def normalize_status(character):
     character.db.buffs = {"Regen": 0, "Vigor": 0, "Protect": 0, "Reflect": 0, "Acuity": 0, "Haste": 0, "Blink": 0,
                           "Bless": 0}
     character.db.debuffs = {"Poison": [0, 0], "Wound": [0, 0], "Curse": [0, 0], "Injure": [0, 0], "Muddle": [0, 0],
-                            "Miasma": [0, 0], "Berserk": [0, 0], "Petrify": [0, 0]}
+                            "Miasma": [0, 0], "Berserk": [0, 0], "Petrify": [0, 0], "Slime": [0, 0]}
     character.db.negative_lf_from_dot = False
     character.db.block_penalty = 0
     character.db.final_action = False
@@ -853,12 +866,18 @@ def display_status_effects(caller):
                            "from using Arts with a Force of less than 50 for 1 more round.")
         elif status_effect == "Petrify" and duration > 0:
             if duration > 1:
-                caller.msg("You are petrified, reducing your Speed and especially your Dodge chances but somewhat"
+                caller.msg("You are petrified, reducing your Speed and especially your Dodge chances but somewhat "
                            "increasing your Block and Endure chances for {duration} rounds.".format(duration=duration))
             else:
-                caller.msg("You are petrified, reducing your Speed and especially your Dodge chances but somewhat"
+                caller.msg("You are petrified, reducing your Speed and especially your Dodge chances but somewhat "
                            "increasing your Block and Endure chances for 1 more round.")
-
+        elif status_effect == "Slime" and duration > 0:
+            if duration > 1:
+                caller.msg("You are slimy, reducing your Speed and especially your Block chances but somewhat "
+                           "increasing your Dodge and Endure chances for {duration} rounds.".format(duration=duration))
+            else:
+                caller.msg("You are slimy, reducing your Speed and especially your Block chances but somewhat "
+                           "increasing your Dodge and Endure chances for 1 more round.")
 
 def apply_buff(action, healer, target):
     # A sub-function for heal_check so that the logic of buff application need not repeat.
@@ -974,6 +993,10 @@ def apply_debuff(action, debuffer, target):
             application_string = "You are petrified, reducing your Speed and especially your Dodge chances but " \
                                  "somewhat increasing your Block and Endure chances."
             extension_string = "The duration of your petrifaction has been extended."
+        elif debuff == "Slime":
+            application_string = "You are slimy, reducing your Speed and especially your Block chances but somewhat " \
+                                 "increasing your Dodge and Endure chances."
+            extension_string = "The duration of your sliminess has been extended."
         # Roll the debuff check
         debuff_check_roll = random.randint(1, 100)
         if debuff_check_roll > debuff_resist:

--- a/world/combat/combat_functions.py
+++ b/world/combat/combat_functions.py
@@ -563,3 +563,15 @@ def dispel_check(target):
         # Return the target's updated status effects if one has been dispelled.
         return modified_status_effects
 
+
+def critical_hits(damage):
+    # Default 5% chance to inflict 1.25x damage. There will be ways to modify that, so put them all here.
+    # Take the current damage as an input and return a bool and possibly modified damage.
+    is_critical = False
+    critical_check = random.randint(1, 100)
+    critical_threshold = 5
+    if critical_check <= critical_threshold:
+        is_critical = True
+        damage *= 1.25
+    return is_critical, damage
+

--- a/world/combat/combat_functions.py
+++ b/world/combat/combat_functions.py
@@ -481,12 +481,22 @@ def apply_buff(action, healer, target):
     application_string = ""
     extension_string = ""
     buff_effects = []
+    serendipity = False
     # Find all the effects on the action that are buffs.
     split_effect_list = action.effects.split()
     for effect in split_effect_list:
+        if effect == "Serendipity":
+            serendipity = True
         for buff in BUFFS:
             if effect == buff.name:
                 buff_effects.append(effect)
+    if serendipity:
+        # Add an additional random buff that is not already one of the Art's effects.
+        buff_options = []
+        for buff in BUFFS:
+            if buff.name not in buff_effects:
+                buff_options.append(buff.name)
+        buff_effects.append(random.choice(buff_options))
     for buff in buff_effects:
         if buff == "Regen":
             application_string = "You will gradually regenerate health."

--- a/world/combat/combat_functions.py
+++ b/world/combat/combat_functions.py
@@ -713,10 +713,16 @@ def wound_check(character, action):
 
 
 def berserk_check(caller, attack):
-    # If an attacker is Berserk, check if the attack is above 50 Force/Damage and, if not, prevent them from attacking.
-    if attack.dmg < 50:
-        return True
-    # Simple for now, but if this seems OP, I may change it so weaker attacks cost more AP or some EX from caller.
+    # If a character is Berserk, Arts of lower than 50 DMG cost 10 more AP. Return "success" if the user has enough AP.
+    ap_change = attack.ap - 10
+    if attack.dmg < 50 and caller.db.ap + ap_change > 0:
+        return "success"
+    # Return "failure" if the user does not have sufficient AP.
+    elif attack.dmg < 50 and caller.db.ap + ap_change < 0:
+        return "failure"
+    # Return NA if the attack was not below 50 DMG to begin with. Berserk will make no change this way.
+    else:
+        return "NA"
 
 
 def hex_counter(caller):
@@ -911,10 +917,10 @@ def display_status_effects(caller):
             duration_string = "You are afflicted by a miasma that halves the effects of healing upon you for {duration} rounds."
             single_string = "You are afflicted by a miasma that halves the effects of healing upon you for 1 more round."
         elif status_effect == "Berserk" and duration > 0:
-            duration_string = "You are berserk, increasing your effective Power, Knowledge, and Speed but preventing you " \
-                              "from using Arts with a Force of less than 50 for {duration} rounds."
-            single_string = "You are berserk, increasing your effective Power, Knowledge, and Speed but preventing you " \
-                            "from using Arts with a Force of less than 50 for 1 more round."
+            duration_string = "You are berserk, increasing your effective Power, Knowledge, and Speed, but also the AP " \
+                              "cost of Arts and Normals with a DMG of less than 50, for {duration} rounds."
+            single_string = "You are berserk, increasing your effective Power, Knowledge, and Speed, but also the AP " \
+                            "cost of Arts and Normals with a DMG of less than 50, for 1 round."
         elif status_effect == "Petrify" and duration > 0:
             duration_string = "You are petrified, reducing your Speed and especially your Dodge chances but somewhat " \
                               "increasing your Block and Endure chances for {duration} rounds."
@@ -1144,7 +1150,7 @@ def apply_debuff(action, debuffer, target):
             extension_string = "The duration of the miasma afflicting you has been extended."
         elif debuff == "Berserk":
             application_string = "You have gone berserk, increasing your effective Power, Knowledge, and Speed but " \
-                                 "compelling you to use more damaging, less accurate attacks."
+                                 "increasing the cost of using less damaging, more accurate attacks."
             extension_string = "The duration of your berserk fury has been extended."
         elif debuff == "Petrify":
             application_string = "You are petrified, reducing your Speed and especially your Dodge chances but " \

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -56,14 +56,16 @@ revive = Effect("Revive", -15, "REV")
 # This healing Art, when used on a KOed ally, eliminates their 1-turn inaction penalty on being healed.
 regen = Effect("Regen", -15, "REGEN")
 # Applies the Regen Effect: Heal the target over time. This healing counts toward the target's per-fight healing limit.
+vigor = Effect("Vigor", -15, "VGR")
+# Applies the Vigor Effect: Increase Power and Knowledge.
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen]
+EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 
-SUPPORT = [regen]
+SUPPORT = [regen, vigor]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -109,6 +109,51 @@ slime = Effect("Slime", -15, "SLM")
 # Applies the Slime Effect: Lower a target's Speed and greatly reduce their Block chance specifically, but somewhat
 # improve their Dodge and Endure chances.
 
+# Debuffs (Transformation)
+
+# Transformation debuffs have dramatic effects but serious limitations. First, they only last for 2 rounds. Second,
+# a target can only be affected by one Transformation debuff at a time. Third, being affected by a Transformation
+# debuff greatly increases the target's resistance to any future Transformation attempts during the fight. Finally,
+# these debuffs have the highest AP costs of any Effects.
+
+morph = Effect("Morph", -25, "MRPH")
+# Inflict a random Transformation Effect.
+bird = Effect("Bird", -35, "BIRD")
+# Turn the target into a bird, effectively halving their Power and Parry.
+frog = Effect("Frog", -35, "FROG")
+# Turn the target into a frog, effectively halving their Power and Barrier.
+pig = Effect("Pig", -35, "PIG")
+# Turn the target into a pig, effectively halving their Knowledge and Parry.
+pumpkin = Effect("Pumpkin", -35, "PMKN")
+# Turn the target into a pumpkin, effectively halving their Knowledge and Barrier. Somehow, they can still hop around.
+
+# Debuffs (Hexes)
+
+# Mechanically, all Hexes cost 10 AP and have the same Distraction effect, persisting for 3 actions: they moderately
+# reduce the target's reaction chances multiplied by the number of different Hexes on the target. Being Hexed also
+# moderately increases the target's resistance to being Hexed again during the fight, a bonus which depreciates with
+# each action. [Even though they're all the same, I want players to be able to pick a single one to inflict, so I'm
+# going to make them distinct Effects.]
+
+hex1 = Effect("Hex1", -10, "HEX1")
+hex2 = Effect("Hex2", -20, "HEX2")
+hex3 = Effect("Hex3", -30, "HEX3")
+# Inflict X number of random Hexes.
+blind = Effect("Blind", -10, "BLN")
+silence = Effect("Silence", -10, "SLN")
+amnesia = Effect("Amnesia", -10, "AMN")
+sleep = Effect("Sleep", -10, "SLP")
+charm = Effect("Charm", -10, "CHR")
+confuse = Effect("Confuse", -10, "CNF")
+fear = Effect("Fear", -10, "FR")
+bind = Effect("Bind", -10, "BND")
+zombie = Effect("Zombie", -10, "ZMB")
+doom = Effect("Doom", -10, "DM")
+dance = Effect("Dance", -10, "DNC")
+stinky = Effect("Stinky", -10, "STN")
+itchy = Effect("Itchy", -10, "ITC")
+old = Effect("Old", -10, "OLD")
+
 # List of all Effects
 
 EFFECTS = [crush,
@@ -141,7 +186,29 @@ EFFECTS = [crush,
            miasma,
            berserk,
            petrify,
-           slime]
+           slime,
+           morph,
+           bird,
+           frog,
+           pig,
+           pumpkin,
+           hex1,
+           hex2,
+           hex3,
+           blind,
+           silence,
+           amnesia,
+           sleep,
+           charm,
+           confuse,
+           fear,
+           bind,
+           zombie,
+           doom,
+           dance,
+           stinky,
+           itchy,
+           old]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -166,7 +233,23 @@ DEBUFFS_STANDARD = [poison,
                     berserk,
                     petrify,
                     slime]
-DEBUFFS_TRANSFORMATION = []
-DEBUFFS_HEXES = []
+DEBUFFS_TRANSFORMATION = [bird,
+                          frog,
+                          pig,
+                          pumpkin]
+DEBUFFS_HEXES = [blind,
+                 silence,
+                 amnesia,
+                 sleep,
+                 charm,
+                 confuse,
+                 fear,
+                 bind,
+                 zombie,
+                 doom,
+                 dance,
+                 stinky,
+                 itchy,
+                 old]
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES
 

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -88,6 +88,9 @@ bless = Effect("Bless", -15, "BLS")
 
 poison = Effect("Poison", -15, "POI")
 # Applies the Poison Effect: Inflicts damage over time.
+wound = Effect("Wound", -15, "WND")
+# Applies the Wound Effect: Whenever this character acts, inflict damage relative to the AP cost of their action.
+# Actions with an AP cost of 0 or less do not inflict damage.
 
 # List of all Effects
 
@@ -113,7 +116,8 @@ EFFECTS = [crush,
            blink,
            serendipity,
            poison,
-           bless]
+           bless,
+           wound]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -129,7 +133,8 @@ SUPPORT = [revive,
            blink,
            bless]
 BUFFS = SUPPORT[2:]
-DEBUFFS_STANDARD = [poison]
+DEBUFFS_STANDARD = [poison,
+                    wound]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -105,6 +105,9 @@ berserk = Effect("Berserk", -15, "BSK")
 petrify = Effect("Petrify", -15, "PTR")
 # Applies the Petrify Effect: Lower a target's Speed and greatly reduce their Dodge chance specifically, but somewhat
 # improve their Block and Endure chances.
+slime = Effect("Slime", -15, "SLM")
+# Applies the Slime Effect: Lower a target's Speed and greatly reduce their Block chance specifically, but somewhat
+# improve their Dodge and Endure chances.
 
 # List of all Effects
 
@@ -137,7 +140,8 @@ EFFECTS = [crush,
            muddle,
            miasma,
            berserk,
-           petrify]
+           petrify,
+           slime]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -160,7 +164,8 @@ DEBUFFS_STANDARD = [poison,
                     muddle,
                     miasma,
                     berserk,
-                    petrify]
+                    petrify,
+                    slime]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -102,6 +102,9 @@ miasma = Effect("Miasma", -15, "MSM")
 berserk = Effect("Berserk", -15, "BSK")
 # Applies the Berserk Effect: Increase the target's Power, Knowledge, and Speed but prevent them from using any Arts
 # below a Force of 50, thus requiring them to use attacks of lower Accuracy.
+petrify = Effect("Petrify", -15, "PTR")
+# Applies the Petrify Effect: Lower a target's Speed and greatly reduce their Dodge chance specifically, but somewhat
+# improve their Block and Endure chances.
 
 # List of all Effects
 
@@ -133,7 +136,8 @@ EFFECTS = [crush,
            injure,
            muddle,
            miasma,
-           berserk]
+           berserk,
+           petrify]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -155,7 +159,8 @@ DEBUFFS_STANDARD = [poison,
                     injure,
                     muddle,
                     miasma,
-                    berserk]
+                    berserk,
+                    petrify]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -83,6 +83,8 @@ serendipity = Effect("Serendipity", -10, "SER")
 # Applies a random effect from BUFFS.
 bless = Effect("Bless", -15, "BLS")
 # Applies the Bless Effect: Increase resistance to all Debuffs.
+purity = Effect("Purity", -15, "PUR")
+# Applies the Purity Effect: Grant immunity to all non-Standard Debuffs, i.e., Transformation and Hexes.
 
 # Debuffs (Standard)
 
@@ -208,7 +210,8 @@ EFFECTS = [crush,
            dance,
            stinky,
            itchy,
-           old]
+           old,
+           purity]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -222,7 +225,8 @@ SUPPORT = [revive,
            acuity,
            haste,
            blink,
-           bless]
+           bless,
+           purity]
 BUFFS = SUPPORT[2:]
 DEBUFFS_STANDARD = [poison,
                     wound,

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -81,6 +81,8 @@ blink = Effect("Blink", -15, "BNK")
 # Applies the Blink Effect: Slightly increase Speed and improve the effectiveness of the Feint command.
 serendipity = Effect("Serendipity", -10, "SER")
 # Applies a random effect from BUFFS.
+bless = Effect("Bless", -15, "BLS")
+# Applies the Bless Effect: Increase resistance to all Debuffs.
 
 # Debuffs (Standard)
 
@@ -89,13 +91,43 @@ poison = Effect("Poison", -15, "POI")
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range, protect, reflect, acuity, haste, blink, serendipity, poison]
+EFFECTS = [crush,
+           sweep,
+           priority,
+           ex_move,
+           rush,
+           weave,
+           brace,
+           bait,
+           heal,
+           revive,
+           drain,
+           regen,
+           vigor,
+           dispel,
+           long_range,
+           protect,
+           reflect,
+           acuity,
+           haste,
+           blink,
+           serendipity,
+           poison,
+           bless]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [revive, serendipity, regen, vigor, protect, reflect, acuity, haste, blink]
+SUPPORT = [revive,
+           serendipity,
+           regen,
+           vigor,
+           protect,
+           reflect,
+           acuity,
+           haste,
+           blink,
+           bless]
 BUFFS = SUPPORT[2:]
 DEBUFFS_STANDARD = [poison]
 DEBUFFS_TRANSFORMATION = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -71,17 +71,19 @@ protect = Effect("Protect", -15, "PRT")
 reflect = Effect("Reflect", -15, "REFL")
 # Applies the Reflect Effect: Slightly increase Barrier and improve damage mitigation when interrupting Knowledge-type
 # attacks, significantly when the interrupt is successful and moderately when it fails.
+acuity = Effect("Acuity", -15, "ACU")
+# Applies the Acuity Effect: Slightly increase Speed and significantly improve chance of critical hits.
 
 # List of all Effects
 
 EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range, protect, reflect]
+           long_range, protect, reflect, acuity]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [revive, regen, vigor, protect, reflect]
-BUFFS = [regen, vigor, protect, reflect]
+SUPPORT = [revive, regen, vigor, protect, reflect, acuity]
+BUFFS = SUPPORT[1:]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -47,6 +47,8 @@ drain = Effect("Drain", -20, "DRN")
 # Note that this healing counts toward the attacker's per-fight healing limit.
 dispel = Effect("Dispel", -10, "DIS")
 # If the attack is successful or endured, remove one random buff from the target.
+strain = Effect("Strain", -5, "STR")
+# Damage oneself in exchange for inflicting more damage on a successful hit, relative to the AP cost of the action.
 
 # Reaction Modifiers
 
@@ -214,7 +216,8 @@ EFFECTS = [crush,
            itchy,
            old,
            purity,
-           cure]
+           cure,
+           strain]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -38,6 +38,8 @@ rush = Effect("Rush", -5, "RSH")
 drain = Effect("Drain", -20, "DRN")
 # If an attack is not dodged, the attacker heals themselves proportionally to the damage they inflict.
 # Note that this healing counts toward the attacker's per-fight healing limit.
+dispel = Effect("Dispel", -10, "DIS")
+# If the attack is successful or endured, remove one random buff from the target.
 
 # Reaction Modifiers
 
@@ -61,11 +63,13 @@ vigor = Effect("Vigor", -15, "VGR")
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor]
+EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
+# SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [regen, vigor]
+SUPPORT = [revive, regen, vigor]
+BUFFS = [regen, vigor]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -91,6 +91,8 @@ poison = Effect("Poison", -15, "POI")
 wound = Effect("Wound", -15, "WND")
 # Applies the Wound Effect: Whenever this character acts, inflict damage relative to the AP cost of their action.
 # Actions with an AP cost of 0 or less do not inflict damage.
+curse = Effect("Curse", -15, "CRS")
+# Applies the Curse Effect: Decrease a target's resistance to all debuffs.
 
 # List of all Effects
 
@@ -117,7 +119,8 @@ EFFECTS = [crush,
            serendipity,
            poison,
            bless,
-           wound]
+           wound,
+           curse]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -134,7 +137,8 @@ SUPPORT = [revive,
            bless]
 BUFFS = SUPPORT[2:]
 DEBUFFS_STANDARD = [poison,
-                    wound]
+                    wound,
+                    curse]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -4,6 +4,8 @@ class AimOrFeint(Enum):
     AIM = 1
     FEINT = 2
     NEUTRAL = 3
+    HASTED_AIM = 4
+    BLINKED_FEINT = 5
 
 class Effect:
     def __init__(self, name: str, ap_change: int, abbr: str):
@@ -73,16 +75,20 @@ reflect = Effect("Reflect", -15, "REFL")
 # attacks, significantly when the interrupt is successful and moderately when it fails.
 acuity = Effect("Acuity", -15, "ACU")
 # Applies the Acuity Effect: Slightly increase Speed and significantly improve chance of critical hits.
+haste = Effect("Haste", -15, "HST")
+# Applies the Haste Effect: Slightly increase Speed and improve the effectiveness of the Aim command.
+blink = Effect("Blink", -15, "BNK")
+# Applies the Blink Effect: Slightly increase Speed and improve the effectiveness of the Feint command.
 
 # List of all Effects
 
 EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range, protect, reflect, acuity]
+           long_range, protect, reflect, acuity, haste, blink]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [revive, regen, vigor, protect, reflect, acuity]
+SUPPORT = [revive, regen, vigor, protect, reflect, acuity, haste, blink]
 BUFFS = SUPPORT[1:]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -99,6 +99,9 @@ muddle = Effect("Muddle", -15, "MDL")
 # Applies the Muddle Effect: Lower the target's Knowledge and Barrier and slightly lower Speed.
 miasma = Effect("Miasma", -15, "MSM")
 # Applies the Miasma Effect: Halves the effectiveness of heals on the target.
+berserk = Effect("Berserk", -15, "BSK")
+# Applies the Berserk Effect: Increase the target's Power, Knowledge, and Speed but prevent them from using any Arts
+# below a Force of 50, thus requiring them to use attacks of lower Accuracy.
 
 # List of all Effects
 
@@ -129,7 +132,8 @@ EFFECTS = [crush,
            curse,
            injure,
            muddle,
-           miasma]
+           miasma,
+           berserk]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -150,7 +154,8 @@ DEBUFFS_STANDARD = [poison,
                     curse,
                     injure,
                     muddle,
-                    miasma]
+                    miasma,
+                    berserk]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -79,17 +79,19 @@ haste = Effect("Haste", -15, "HST")
 # Applies the Haste Effect: Slightly increase Speed and improve the effectiveness of the Aim command.
 blink = Effect("Blink", -15, "BNK")
 # Applies the Blink Effect: Slightly increase Speed and improve the effectiveness of the Feint command.
+serendipity = Effect("Serendipity", -10, "SER")
+# Applies a random effect from BUFFS.
 
 # List of all Effects
 
 EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range, protect, reflect, acuity, haste, blink]
+           long_range, protect, reflect, acuity, haste, blink, serendipity]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [revive, regen, vigor, protect, reflect, acuity, haste, blink]
-BUFFS = SUPPORT[1:]
+SUPPORT = [revive, serendipity, regen, vigor, protect, reflect, acuity, haste, blink]
+BUFFS = SUPPORT[2:]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -54,15 +54,16 @@ heal = Effect("Heal", -10, "HEAL")
 # This Art heals instead of doing damage and is subject to heal depreciation.
 revive = Effect("Revive", -15, "REV")
 # This healing Art, when used on a KOed ally, eliminates their 1-turn inaction penalty on being healed.
-
+regen = Effect("Regen", -15, "REGEN")
+# Applies the Regen Effect: Heal the target over time. This healing counts toward the target's per-fight healing limit.
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain]
+EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 
-SUPPORT = []
+SUPPORT = [regen]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -65,17 +65,23 @@ regen = Effect("Regen", -15, "REGEN")
 # Applies the Regen Effect: Heal the target over time. This healing counts toward the target's per-fight healing limit.
 vigor = Effect("Vigor", -15, "VGR")
 # Applies the Vigor Effect: Increase Power and Knowledge.
+protect = Effect("Protect", -15, "PRT")
+# Applies the Protect Effect: Slightly increase Parry and improve damage mitigation when interrupting Power-type
+# attacks, significantly when the interrupt is successful and moderately when it fails.
+reflect = Effect("Reflect", -15, "REFL")
+# Applies the Reflect Effect: Slightly increase Barrier and improve damage mitigation when interrupting Knowledge-type
+# attacks, significantly when the interrupt is successful and moderately when it fails.
 
 # List of all Effects
 
 EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range]
+           long_range, protect, reflect]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
-SUPPORT = [revive, regen, vigor]
-BUFFS = [regen, vigor]
+SUPPORT = [revive, regen, vigor, protect, reflect]
+BUFFS = [regen, vigor, protect, reflect]
 DEBUFFS_STANDARD = []
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -85,6 +85,8 @@ bless = Effect("Bless", -15, "BLS")
 # Applies the Bless Effect: Increase resistance to all Debuffs.
 purity = Effect("Purity", -15, "PUR")
 # Applies the Purity Effect: Grant immunity to all non-Standard Debuffs, i.e., Transformation and Hexes.
+cure = Effect("Cure", -10, "CURE")
+# Removes a random debuff, or a specific debuff with the switch "heal/[name of debuff]". Heal is an alias of CmdAttack.
 
 # Debuffs (Standard)
 
@@ -211,13 +213,15 @@ EFFECTS = [crush,
            stinky,
            itchy,
            old,
-           purity]
+           purity,
+           cure]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
 SUPPORT = [revive,
            serendipity,
+           cure,
            regen,
            vigor,
            protect,
@@ -227,7 +231,7 @@ SUPPORT = [revive,
            blink,
            bless,
            purity]
-BUFFS = SUPPORT[2:]
+BUFFS = SUPPORT[3:]
 DEBUFFS_STANDARD = [poison,
                     wound,
                     curse,

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -93,6 +93,10 @@ wound = Effect("Wound", -15, "WND")
 # Actions with an AP cost of 0 or less do not inflict damage.
 curse = Effect("Curse", -15, "CRS")
 # Applies the Curse Effect: Decrease a target's resistance to all debuffs.
+injure = Effect("Injure", -15, "INJ")
+# Applies the Injure Effect: Lower the target's Power and Parry and slightly lower Speed.
+muddle = Effect("Muddle", -15, "MDL")
+# Applies the Muddle Effect:  Lower the target's Knowledge and Barrier and slightly lower Speed.
 
 # List of all Effects
 
@@ -120,7 +124,9 @@ EFFECTS = [crush,
            poison,
            bless,
            wound,
-           curse]
+           curse,
+           injure,
+           muddle]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -138,7 +144,9 @@ SUPPORT = [revive,
 BUFFS = SUPPORT[2:]
 DEBUFFS_STANDARD = [poison,
                     wound,
-                    curse]
+                    curse,
+                    injure,
+                    muddle]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -82,16 +82,23 @@ blink = Effect("Blink", -15, "BNK")
 serendipity = Effect("Serendipity", -10, "SER")
 # Applies a random effect from BUFFS.
 
+# Debuffs (Standard)
+
+poison = Effect("Poison", -15, "POI")
+# Applies the Poison Effect: Inflicts damage over time.
+
 # List of all Effects
 
 EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
-           long_range, protect, reflect, acuity, haste, blink, serendipity]
+           long_range, protect, reflect, acuity, haste, blink, serendipity, poison]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
 
 SUPPORT = [revive, serendipity, regen, vigor, protect, reflect, acuity, haste, blink]
 BUFFS = SUPPORT[2:]
-DEBUFFS_STANDARD = []
+DEBUFFS_STANDARD = [poison]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
+DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES
+

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -96,7 +96,9 @@ curse = Effect("Curse", -15, "CRS")
 injure = Effect("Injure", -15, "INJ")
 # Applies the Injure Effect: Lower the target's Power and Parry and slightly lower Speed.
 muddle = Effect("Muddle", -15, "MDL")
-# Applies the Muddle Effect:  Lower the target's Knowledge and Barrier and slightly lower Speed.
+# Applies the Muddle Effect: Lower the target's Knowledge and Barrier and slightly lower Speed.
+miasma = Effect("Miasma", -15, "MSM")
+# Applies the Miasma Effect: Halves the effectiveness of heals on the target.
 
 # List of all Effects
 
@@ -126,7 +128,8 @@ EFFECTS = [crush,
            wound,
            curse,
            injure,
-           muddle]
+           muddle,
+           miasma]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.
@@ -146,7 +149,8 @@ DEBUFFS_STANDARD = [poison,
                     wound,
                     curse,
                     injure,
-                    muddle]
+                    muddle,
+                    miasma]
 DEBUFFS_TRANSFORMATION = []
 DEBUFFS_HEXES = []
 DEBUFFS = DEBUFFS_STANDARD + DEBUFFS_TRANSFORMATION + DEBUFFS_HEXES

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -35,6 +35,11 @@ ex_move = Effect("EX", 5, "EX")
 rush = Effect("Rush", -5, "RSH")
 # 1) Increase accuracy if not used as interrupt. 2) Decrease all reaction chances until next action.
 # This is a hybrid Attack Enhancer / Reaction Modifier.
+long_range = Effect("Long-Range", -10, "RNGD")
+# This attack is harder to interrupt with non-Ranged attacks and, if not dodged or interrupted, inflicts a "knockback"
+# accuracy penalty to the target until their next action. In exchange, slightly decrease both the attack's accuracy and
+# all the attacker's reaction chances until next action.
+# This is also a hybrid Attack Enhancer / Reaction Modifier.
 drain = Effect("Drain", -20, "DRN")
 # If an attack is not dodged, the attacker heals themselves proportionally to the damage they inflict.
 # Note that this healing counts toward the attacker's per-fight healing limit.
@@ -63,7 +68,8 @@ vigor = Effect("Vigor", -15, "VGR")
 
 # List of all Effects
 
-EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel]
+EFFECTS = [crush, sweep, priority, ex_move, rush, weave, brace, bait, heal, revive, drain, regen, vigor, dispel,
+           long_range]
 
 # Lists of Support and Debuff Effects, Specifically, for Dispel/Cure/Serendipity/Curse/Etc.
 # SUPPORT are flags that must be accompanied by Heal. BUFFS are options for random selection, e.g., Serendipity, Dispel.

--- a/world/utilities/utilities.py
+++ b/world/utilities/utilities.py
@@ -1,4 +1,4 @@
-from evennia import EvTable
+from evennia.utils import evtable
 from world.combat.effects import EFFECTS
 from evennia.objects.models import ObjectDB
 
@@ -14,11 +14,11 @@ def location_character_search(location):
 # creates the approriate evtable object given the contextual bools
 def setup_table(client_width, is_sheet=False, is_check=False):
     if is_sheet:
-        table = EvTable("Name", "AP", "Dmg", "Acc", "Stat", "Effects",
+        table = evtable.EvTable("Name", "AP", "Dmg", "Acc", "Stat", "Effects",
                                      border_left_char="|", border_right_char="|", border_top_char="",
                                      border_bottom_char="-", width=client_width)
     else:
-        table = EvTable("Name", "AP", "Dmg", "Acc", "Stat", "Effects",
+        table = evtable.EvTable("Name", "AP", "Dmg", "Acc", "Stat", "Effects",
                                     border_left_char="|", border_right_char="|", border_top_char="-",
                                     border_bottom_char="-", width=client_width)
     table.reformat_column(1, width=7)

--- a/world/utilities/utilities.py
+++ b/world/utilities/utilities.py
@@ -40,9 +40,10 @@ def get_abbreviations(action):
 
     return effects_abbrev
 
+
 # in-place modification of the evtable that populates it with attacks or arts. Note that CmdCheck duplicates this code
 # because there wasn't an overdesigned way to have this function take care of that edge case too
-def populate_table(table, actions):
+def populate_table(table, actions, caller):
     for action in actions:
         stat_string = action.stat
         if stat_string == "Power":
@@ -52,13 +53,24 @@ def populate_table(table, actions):
 
         effects_abbrev = get_abbreviations(action)
 
+        ap_string = modify_ap_string(action, caller)
         table.add_row(action.name,
-                      "|g" + str(action.ap) + "|n",
+                      ap_string,
                       action.dmg,
                       action.acc,
                       stat_string,
                       effects_abbrev)
     return table
+
+
+def modify_ap_string(action, caller):
+    # Define default ap_string.
+    ap_string = "|g" + str(action.ap) + "|n"
+    # If the caller is Berserk and the attack's damage is less than 50, it will appear in red and with a higher cost.
+    if caller.db.debuffs_standard["Berserk"] > 0:
+        if action.dmg < 50:
+            ap_string = "|r" + str(action.ap - 10) + "|n"
+    return ap_string
 
 
 def logger(caller, message, level="info"):

--- a/world/utilities/utilities.py
+++ b/world/utilities/utilities.py
@@ -1,5 +1,6 @@
 from evennia import EvTable
 from world.combat.effects import EFFECTS
+from evennia.objects.models import ObjectDB
 
 def location_character_search(location):
     location_objects = location.contents
@@ -67,3 +68,12 @@ def logger(caller, message, level="info"):
     # We're just putting in this if/else statement provisionally for when we implement more involved debug logging.
     else:
         caller.msg("|cDEBUG:|n " + message)
+
+
+def find_attacker_from_key(attacker_key):
+    # This finds the attacker's character object from their key.
+    # Because Evennia uses Python's default pickling method, we cannot pass character objects directly into a queue.
+    all_objects = ObjectDB.objects.all()
+    attacker_queryset = all_objects.filter(db_key=attacker_key)
+    attacker = attacker_queryset[0]
+    return attacker


### PR DESCRIPTION
* Added the regen_duration character flag.
* If regen_duration > 0 during a combat tick, a mini self-heal happens through heal_check (and is thus modified by how much the character has been healed already, like Drain).
* heal_check has lots of different flavor test now depending on various events, e.g., it was your final action but you regenerated back to positive LF in the nick of time.
* Chargen's SetArt now checks through SUPPORT in effects.py to make sure that any Support effect (for now, just Regen) is also accompanied by the Heal effect, as intended.
* restore normalizes regen_duration to 0. 
Also fixed a serious combat bug arising from my mistaken design of combat_tick and apply_attack_effects_to_attacker where I was, e.g., clearing endure bonus before applying it to the attack. Now combat_tick happens "after" the attack and apply happens "before" it, and I've reorganized both functions accordingly.