### PR TITLE
Fixing bad read migrations from PR #8

### DIFF
--- a/world/boards/migrations/0001_initial.py
+++ b/world/boards/migrations/0001_initial.py
@@ -9,7 +9,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ("objects", "0014_defaultobject_defaultcharacter_defaultexit_and_more"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
PR #8 was created in a bad dev environment that had wrongly-created evennia core migrations. Deleted the incorrect dependency (on a non-existent core evennia migration) and it all appears to be working in a brand new clean environment.