### PR TITLE
Session NoneType filtering

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -350,6 +350,8 @@ class CmdWho(default_cmds.MuxCommand):
 
         account = self.account
         all_sessions = SESSIONS.get_sessions()
+        # Not sure how a None entry is sneaking into all_sessions, but we did run into this
+        all_sessions = [session for session in all_sessions if session is not None]
 
         all_sessions = sorted(all_sessions, key=lambda o: o.account.key) # sort sessions by account name
         pruned_sessions = prune_sessions(all_sessions)

--- a/commands/mush_core.py
+++ b/commands/mush_core.py
@@ -115,6 +115,8 @@ class CmdPot(default_cmds.MuxCommand):
         """
 
         all_sessions = SESSIONS.get_sessions()
+        # Not sure how a None entry is sneaking into all_sessions, but we did run into this so filtering Nones here
+        all_sessions = [session for session in all_sessions if session is not None]
 
         all_sessions = sorted(all_sessions, key=lambda o: o.puppet.get_pose_time()) # sort by last posed time
         pruned_sessions = prune_sessions(all_sessions)


### PR DESCRIPTION
Users were running into a bug with who and pot where objects were unexpectedly NoneType. We still don't know why this is happening, but we've filtered out all None objects so we never run into this state. Fuck it.