### PR TITLE
Filter out unpuppeted sessions

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -350,8 +350,8 @@ class CmdWho(default_cmds.MuxCommand):
 
         account = self.account
         all_sessions = SESSIONS.get_sessions()
-        # Not sure how a None entry is sneaking into all_sessions, but we did run into this
-        all_sessions = [session for session in all_sessions if session is not None]
+        # Not quite sure how a non-puppeted session can exist - need to dig into this
+        all_sessions = [session for session in all_sessions if session.puppet is not None]
 
         all_sessions = sorted(all_sessions, key=lambda o: o.account.key) # sort sessions by account name
         pruned_sessions = prune_sessions(all_sessions)

--- a/commands/mush_core.py
+++ b/commands/mush_core.py
@@ -115,8 +115,8 @@ class CmdPot(default_cmds.MuxCommand):
         """
 
         all_sessions = SESSIONS.get_sessions()
-        # Not sure how a None entry is sneaking into all_sessions, but we did run into this so filtering Nones here
-        all_sessions = [session for session in all_sessions if session is not None]
+        # Not quite sure how a non-puppeted session can exist - need to dig into this
+        all_sessions = [session for session in all_sessions if session.puppet is not None]
 
         all_sessions = sorted(all_sessions, key=lambda o: o.puppet.get_pose_time()) # sort by last posed time
         pruned_sessions = prune_sessions(all_sessions)


### PR DESCRIPTION
I was wrong - it's not the the sessions themselves were NoneType, it's that some sessions were unpuppeted, so session.puppet was returning None. Still not sure why this is happening, but needs an immediate fix so simply filter them out for now.