### PR TITLE
Implemented filter_and_modify_arts, a combat function that centralize…

### DIFF
--- a/world/arts/models.py
+++ b/world/arts/models.py
@@ -53,7 +53,7 @@ class Arts(models.Model):
     def addArt(cls, art: Attack, is_normal=False):
         Arts.objects.create(
             name=art.name,
-            ap=art.ap_change,
+            ap=art.ap,
             dmg=art.dmg,
             acc=art.acc,
             stat=art.base_stat,

--- a/world/combat/attacks.py
+++ b/world/combat/attacks.py
@@ -5,12 +5,12 @@ from enum import Enum
 
 class Attack:
     # This is the attack object as stored in individual lists of Arts or in the universal list of Normals.
-    def __init__(self, name: str, ap_change: int, dmg: int, acc: int, base_stat="", effects=[]):
+    def __init__(self, name: str, ap: int, dmg: int, acc: int, base_stat="", effects=""):
         self.name = name # make case-insensitive
-        self.ap_change = ap_change
+        self.ap = ap
         self.dmg = dmg
         self.acc = acc
-        self.base_stat = base_stat
+        self.stat = base_stat
         self.effects = effects
 
     def __str__(self):

--- a/world/combat/effects.py
+++ b/world/combat/effects.py
@@ -8,9 +8,9 @@ class AimOrFeint(Enum):
     BLINKED_FEINT = 5
 
 class Effect:
-    def __init__(self, name: str, ap_change: int, abbr: str):
+    def __init__(self, name: str, ap: int, abbr: str):
         self.name = name
-        self.ap_change = ap_change
+        self.ap = ap
         self.abbreviation = abbr
 
     def __eq__(self, other):


### PR DESCRIPTION
…s the copying of Arts objects from our database and modifies the copies by calling appropriate other functions, e.g., berserk_check. Filter_and_modify_arts is designed to work for both attacking (CmdAttack and CmdInterrupt) and displaying info (CmdSheet, CmdArts, CmdListAttacks, CmdCheck) and, for display purposes, produces a "baseline" copy of an art for self-comparison: e.g., if the AP cost went up overall, we'll know from comparison to the baseline object (so utilities.py doesn't need to reach directly into the Arts table to compare).

I had to rename a few things, like the ap_change attribute of the Attack class to match the ap attribute of the Arts model (because we didn't want to migrate the model and rename that instead, even if ap_change is a more accurate name and ap could be confused with the current AP of a character. I'm sure this change won't ever come back to bite us in the ass.)

Everything works well in testing EXCEPT CmdCheck when called to check interrupt chances BECAUSE CmdCheck doesn't actually use the functions in utilities.py yet as we've been meaning to refactor it for a long time. So I'm pushing this mostly-complete functionality now, and I'll refactor CmdCheck next so that it populates its tables in a more standardized way.