### PR TITLE
Minor cleanup from to-do:

### DIFF
--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -71,6 +71,9 @@ class CmdSetArt(default_cmds.MuxCommand):
         except ValueError:
             return caller.msg("Error: your damage value must be an integer. Make sure that your format is: name, damage"
                               " value, base stat, and effects (if any).")
+        # Setting a lower bound on damage.
+        if damage_int < 1:
+            return caller.msg("Error: your damage value must be at least 1.")
         # Base accuracy for Arts will be 12 - damage_int, increased by 2 for EX moves after effects are checked.
         accuracy = 12 - damage_int
         base_stat = art_list[2].lower()

--- a/commands/combat.py
+++ b/commands/combat.py
@@ -312,8 +312,6 @@ class CmdAttack(default_cmds.MuxCommand):
             heal = AttackDuringAction(action_clean, caller.key, switches)
             heal_check(heal, caller, target_object, switches)
         else:
-            # action_clean.dmg = modify_damage(action_clean, caller)
-
             new_id = assign_attack_instance_id(target_object)
 
             # Confirm here before passing along the attack that the switch is a valid one.
@@ -736,7 +734,6 @@ class CmdInterrupt(default_cmds.MuxCommand):
         # In case of interrupt success
         else:
             # Modify damage of outgoing interrupt based on relevant attack stat.
-            # modified_int_damage = modify_damage(outgoing_interrupt, caller)
             final_outgoing_damage = damage_calc(interrupt, attacker)
 
             # Check if the interrupt is a critical hit!
@@ -994,7 +991,8 @@ class CmdFeint(default_cmds.MuxCommand):
 class CmdRestore(default_cmds.MuxCommand):
     """
         Sets your LF to 1000, your AP to 50, and your EX to 0,
-        and normalizes your status (e.g., sets block penalty to 0).
+        normalizes your status (e.g., sets block penalty to 0),
+        and empties your queue of incoming attacks.
 
         Usage:
           +restore
@@ -1013,9 +1011,11 @@ class CmdRestore(default_cmds.MuxCommand):
         caller.db.ap = 50
         # Set EX to 0.
         caller.db.ex = 0
+        # Empty queue.
+        caller.db.queue = []
         # Run the normalize_status function.
         normalize_status(caller)
-        caller.msg("Your LF, AP, EX, and status effects have been reset.")
+        caller.msg("Your LF, AP, EX, queue, and status effects have been reset.")
 
 
 class CmdPass(default_cmds.MuxCommand):

--- a/world/combat/combat_functions.py
+++ b/world/combat/combat_functions.py
@@ -599,6 +599,8 @@ def heal_check(action, healer, target, switches, regen=False, drain_dmg=None):
     # Currently, there's minimal variance above 80 Accuracy, and then more as you go down.
     # TODO: More complex calculation for slope of increase in variance as accuracy decreases.
     accuracy = heal_instance.acc * 10
+    # Currently, the max accuracy is 80 and the min base_variance is 1 (as in 81 - 80) * 3, or 3.
+    # random.randrange won't work with 0, so I had to make sure it's passed a number greater than that.
     if accuracy > 80:
         accuracy = 80
     base_variance = math.ceil((81 - accuracy) * 3)

--- a/world/utilities/tables.py
+++ b/world/utilities/tables.py
@@ -54,7 +54,7 @@ def populate_table(table, actions, base_arts, interrupted_action=None, caller=No
                           action.acc,
                           stat_string,
                           effects_abbrev,
-                          modified_acc)
+                          int(modified_acc))
         else:
             table.add_row(action.name,
                           ap_string,


### PR DESCRIPTION
* Modified populate_table so when using CmdCheck to look at interrupt chances, floats become integers and are abbreviated.
* CmdRestore now clears the queue, which is useful when there are outdated versions of Arts lurking there and we don't know why things are bugging out.
* Corner cased Setart to have a lower bound on damage values.
* Added a comment explaining heal_check's variance nonsense. Did not do the TO-DO to actually replace the variance nonsense with something more sensible. Never!! I will never do it!!!! I'll do it someday.
* Deleted two stray comments from combat.py. Thanks, Ugen! I love you.